### PR TITLE
content/organization/get-involved: Rewrite page (copied from manuals)

### DIFF
--- a/content/organization/get-involved.md
+++ b/content/organization/get-involved.md
@@ -3,127 +3,46 @@ title = "Get involved"
 template = "page-with-toc.html"
 +++
 
-We are always looking for both **people and institutions** that can promote the
-FAIRness of software management and development practice. There are many ways
-that **you can join and get involved and help the project**:
+CodeRefinery is an open-source project.  All our work is open, and we
+accept any type of contributions: there is a lot more than instructing
+to run a successful workshop.  Also, CodeRefinery is really more of a
+group of like-minded people than one particular plan, so you are
+welcome to join just to hang out and share ideas.
+
+[Read more about
+contributing](https://coderefinery.github.io/manuals/contributing/).
 
 
-### As helper or exercise lead
+## Join our "community teaching training"
 
-Have you already participated in a Carpentry or CodeRefinery workshop, but
-would like to attend another one to refresh your memory and share your own
-knowledge? Or do you already have a solid background in research software
-engineering and would like to meet like-minded people in a friendly
-environment? Join a Carpentry or CodeRefinery workshop as a helper! For more
-information about what a helper is supposed to do, please
-refer [Helper’s guide](https://coderefinery.github.io/manuals/helping-and-teaching/).
-You don't have to know everything and be able to solve all exercises and
-problems.  We will anyway prepare all exercise leads in an on-boarding session.
+CodeRefinery isn’t just about doing teaching ourselves, but improving
+your teaching. Whether you focus on teaching, or it’s a side-activity
+to your other tasks, the CodeRefinery (online) teaching can help you
+avoid re-inventing good practices and prepare you for teaching
+together.
 
+Read more: [Community teaching training](https://coderefinery.github.io/community-teaching/)
 
-### Bring your team
+## Advertise and co-teach in our online courses
 
-Bringing a team of your colleagues or friends is a great way to participate in
-a workshop: you probably "speak" the same programming language and academic
-domain language, can use relatable examples, and already know each other. After
-the workshops, exercise teams can form supporting groups for the weeks and
-months after. And maybe one or two people from your team are a little bit more
-familiar with the tools than others and then they can join as exercise leads?
+CodeRefinery runs many open, online courses, which anyone can
+attend. Some of them can be attended by anyone via livestream, even
+without registering (yes, this really works - we get high ratings for
+this). You could simply advertise our courses, or go even further and
+run local breakout rooms. Take it a step further and help out with the
+teaching, too.
 
+Read more: [Local advertisement and breakout rooms](https://coderefinery.github.io/manuals/local-breakout-rooms/) and [Roles overview](https://coderefinery.github.io/manuals/roles-overview/).
 
-### Co-teach with others
+## Teach openly and allow others to join
 
-Join a workshop organized by others as a co-instructor. Co-teaching is a fun
-and low-preparation way to get involved in teaching. Co-teaching is also a nice
-way for learners to follow a dialogue instead of a monologue and to learn
-different views about technologies and tools and techniques.
+Go to the next level and adopt CodeRefinery strategies for your own
+courses, so that others can join at little cost to yourself. By
+opening, you start to find more lesson developers and instructors, so
+that your courses can reach the next level of quality and
+impact. Soon, you will wonder why you ever bothered teaching alone.
 
-
-### Become an instructor
-
-There is no requirement for using our training material. However, 
-we suggest that most instructors start with [Carpentries instructor
-training](https://carpentries.org/become-instructor/). We have [instructor
-training](https://coderefinery.github.io/instructor-training/), but
-this mostly serves as a complement focused on our lessons and more
-intermediate users.
-
-After taking either instructor training, you are welcome to
-self-organize a CodeRefinery workshop or join a workshop as an
-instructor when instructors are recruited via #workshop stream of
-[CodeRefinery Zulip chat](https://coderefinery.github.io/manuals/chat/).
-
-With that being said, there are no strict requirements to working with
-us and learning "on the job": we help people organically grow from
-learner → helper → instructor.  So far, the best way to get involved is to
-join our chat and let us know when you see something you are
-interested in.
+Read more: [Open your courses to others](https://coderefinery.github.io/manuals/open-your-courses/)
 
 
-### As research group
 
-A great way to both benefit and contribute is to send the group as team:
-contributing not only learners but also one or two exercise leads. This allows
-us to scale and will be a great learning experience also for the exercise
-leads.
-
-
-### As group leader
-
-- By helping us promoting our workshops in your group.
-- Mentioning our activities to your colleagues at faculty meetings.
-- Allowing your students and staff to participate.
-
-
-### As organization
-
-You can support us by:
-- Allowing your staff to contribute in-kind and co-teach and co-organize with us: this is a great learning experience.
-- Helping us advertise our events to your students and staff: the more help we get with advertising and logistics, the more
-  your students and staff will benefit.
-- Sponsoring our activities (see below).
-
-
-### As sponsor
-
-CodeRefinery is working on defining membership tiers with associated benefits
-to continue its activities.  We will offer different options such as:
-- Free membership with no in-kind trainers
-- Free membership with in-kind trainers
-- Basic annual membership
-- Premium annual membership
-
-We are working on defining the benefits for each option.
-
-
-### Host a self-organized CodeRefinery workshop
-
-The requirements for a self-organized CodeRefinery workshop are:
-- Teach at least three CodeRefinery lessons (we recommend one from the section **For yourself and larger**, one from **For your group and larger** and one from **For the community**);
-- Have at least one certified Carpentry or CodeRefinery instructor;
-- Use CodeRefinery surveys to get evaluations and to help us collect feedback from the learners;
-- Abide by [CodeRefinery's Code of Conduct](https://coderefinery.org/about/code-of-conduct/);
-
-There is **no administrative fee** to run a self-organized CodeRefinery workshop. 
-
-If your workshop fulfill the requirements detailed above, it can be listed as a
-"self-organized CodeRefinery workshop" on our website. Please [get in
-touch](/organization/contact/) with us since it is good for us to list
-workshops using our material.
-
-
-### Improving the course material
-
-All our material is open. It is steadily evolving and you can help us making it better:
-- [Reusing our lessons](/lessons/reusing/)
-- [Contributing to our lessons](/lessons/contributing/)
-- Also opening issues about errors or suggestions help
-- Sharing ideas/suggestions for lessons we are missing
-
-
-### Shaping the governance structure
-
-We are a community project and as such we are currently working at establishing
-the CodeRefinery governance and you can help us shaping the governance
-structure! The more diverse input we receive, the better the project will be.
-We also seek help in establishing the project as a non-profit organization.

--- a/content/organization/get-involved.md
+++ b/content/organization/get-involved.md
@@ -1,6 +1,6 @@
 +++
 title = "Get involved"
-template = "page-with-toc.html"
+template = "page.html"
 +++
 
 CodeRefinery is an open-source project.  All our work is open, and we
@@ -9,33 +9,68 @@ to run a successful workshop.  Also, CodeRefinery is really more of a
 group of like-minded people than one particular plan, so you are
 welcome to join just to hang out and share ideas.
 
-[Read more about
-contributing](https://coderefinery.github.io/manuals/contributing/).
-Don't forget that anyone can be an Exercise Leader in individual
-workshops, co-teach, or contribute to lessons.
+- The best way to get started is to [join our
+  chat](https://coderefinery.github.io/manuals/chat/) and introduce
+  yourself in `#new members`.
+- Subscribe to [@coderefine on
+  twitter](https://twitter.com/coderefine) for announcements.
+- [Organizational support and becoming
+  partner](/organization/partners/)
+- [Request a workshop](/workshops/request/)
+- [Reuse our lessons](/lessons/reusing/)
+- [Join our meetings](/organization/meetings/)
+- [More detail about contributing in our
+  manuals](https://coderefinery.github.io/manuals/contributing/)
 
 
 
-## Join our "community teaching training"
+## Volunteer for a workshop
+
+Have you already participated in a Carpentry or CodeRefinery workshop, but
+would like to attend another one to refresh your memory and share your own
+knowledge? Or do you already have a solid background in research software
+engineering and would like to meet like-minded people in a friendly
+environment?  Join a workshop as an [exercise
+leader](https://coderefinery.github.io/manuals/exercise-leaders/),
+[helper](https://coderefinery.github.io/manuals/expert-helpers/), as a
+co-instructor.  Because of our [team
+teaching](https://coderefinery.github.io/manuals/team-teaching/),
+being a co-instructor is actually the second-easiest way to get started!
+You don't need to know everything, we work together.
+
+Have a research group or some friends?  Form a team and be the
+exercise leader.
+
+Read more: [Exercise
+leader](https://coderefinery.github.io/manuals/helping-and-teaching/)
+or [other roles](https://coderefinery.github.io/manuals/roles-overview/)
+
+
+
+## Advertise our workshops
+
+CodeRefinery runs many open, online courses, which anyone can
+attend. Some of them can be attended by anyone via livestream, even
+without registering (yes, this really works - we get high ratings for
+this). You could simply advertise our courses (to your institution or
+research group), or go even further and
+run local breakout rooms.
+
+Read more: [Local advertisement and breakout rooms](https://coderefinery.github.io/manuals/local-breakout-rooms/) and [Roles overview](https://coderefinery.github.io/manuals/roles-overview/).
+
+
+
+## Join our "community teaching training" ("instructor training")
 
 CodeRefinery isn’t just about doing teaching ourselves, but improving
 your teaching. Whether you focus on teaching, or it’s a side-activity
 to your other tasks, the CodeRefinery (online) teaching can help you
 avoid re-inventing good practices and prepare you for teaching
-together.
+together.  **If you teach practical computing skills, you need this workshop.**
 
 Read more: [Community teaching training](https://coderefinery.github.io/community-teaching/)
 
-## Advertise and co-teach in our online courses
 
-CodeRefinery runs many open, online courses, which anyone can
-attend. Some of them can be attended by anyone via livestream, even
-without registering (yes, this really works - we get high ratings for
-this). You could simply advertise our courses, or go even further and
-run local breakout rooms. Take it a step further and help out with the
-teaching, too.
-
-Read more: [Local advertisement and breakout rooms](https://coderefinery.github.io/manuals/local-breakout-rooms/) and [Roles overview](https://coderefinery.github.io/manuals/roles-overview/).
 
 ## Teach openly and allow others to join
 

--- a/content/organization/get-involved.md
+++ b/content/organization/get-involved.md
@@ -11,6 +11,9 @@ welcome to join just to hang out and share ideas.
 
 [Read more about
 contributing](https://coderefinery.github.io/manuals/contributing/).
+Don't forget that anyone can be an Exercise Leader in individual
+workshops, co-teach, or contribute to lessons.
+
 
 
 ## Join our "community teaching training"


### PR DESCRIPTION
- This page was quite long and my guess was too long to make an impact
  on people.  This tries to make it shorter and present a few limited
  options.

- Content is from the manuals page (currently a copy and paste but I
  expect they will diverge, this becomes simpler and manuals goes more
  in depth)

- I think most things that were on the page before are covered by what
  was added, or are somewhere else, or will be.  The only possible
  things is a "call to be a helper/volunteer for a workshop" - I think
  this could be more focused on certain workshops' pages rather than
  here.  Or it could be added back here later.

- Review: check if this is the right direction.
